### PR TITLE
GitHub/multiple cppunit download sources

### DIFF
--- a/.github/workflows/build-n-release.yml
+++ b/.github/workflows/build-n-release.yml
@@ -186,8 +186,12 @@ jobs:
             from nsis_build import *
             # ----- nsis_build.py -----
             cppunitdir = os.path.join(r'${{github.workspace}}', 'cppunit')
-            git_checkout('git://anongit.freedesktop.org/git/libreoffice/cppunit', cppunitdir)   # git server is sometimes down
-            # download_cppunit(cppunitdir)     # webserver is sometimes down
+            try:
+              # git server sometimes times out
+              git_checkout('git://anongit.freedesktop.org/git/libreoffice/cppunit', cppunitdir)
+            except:
+              # fallback to mirror server
+              download_cppunit(cppunitdir)
             build_cppunit(r'${{matrix.compiler}}', r'${{matrix.arch}}', cppunitdir)
 
       - name: Build NSIS

--- a/nsis_build.py
+++ b/nsis_build.py
@@ -187,16 +187,17 @@ def download_cppunit(cppunitdir):
         version = '1.15.1'
         url = f'https://dev-www.libreoffice.org/src/cppunit-{version}.tar.gz'
         tgz = f'{cppunitdir}-{version}.tar.gz'
-        print(f'downloading {url} -> {tgz} ...')
+        print(f'downloading {url}')
         from urllib import request
         with request.urlopen(url) as http:
             with open(tgz, 'wb') as fout:
                 fout.write(http.read())
-        print('extracting ...')
+        print(f'extracting {tgz}')
         import tarfile
         with tarfile.open(tgz) as tf:
             memberlist = [m for m in tf.getmembers() if m.name.startswith(f'cppunit-{version}')]
             tf.extractall(path.dirname(cppunitdir), memberlist, numeric_owner=True, filter='data')
+        print('rename "' + f'cppunit-{version}' + f'" -> "{cppunitdir}"')
         os.rename(path.join(path.dirname(cppunitdir), f'cppunit-{version}'), cppunitdir)
 
 


### PR DESCRIPTION
Its git server is sometimes down, so we fall back to downloading from a mirror web server