### PR TITLE
Header `Util.nsh` not included by legacy `MUI.nsh` leading to undefin…

### DIFF
--- a/Contrib/Modern UI/System.nsh
+++ b/Contrib/Modern UI/System.nsh
@@ -23,6 +23,7 @@ Copyright 2002-2026 Joost Verburg
 !include InstallOptions.nsh
 !include LangFile.nsh
 !include WinMessages.nsh
+!include Util.nsh
 
 Var MUI_TEMP1
 Var MUI_TEMP2


### PR DESCRIPTION
Header `Util.nsh` not included by legacy `MUI.nsh` leading to undefined `${IsHighContrastModeActive}`
Compile error:
```
!include "MUI.nsh"
...
!insertmacro: MUI_PAGE_FINISH
!insertmacro: macro "_If" requires 4 parameter(s), passed 2!
Error in macro MUI_FUNCTION_FINISHPAGE on macroline 325
Error in macro MUI_PAGE_FINISH on macroline 45
Error in script "project.nsi" on line 559 -- aborting creation process
```