### PR TITLE
Replace `mingw` with `winlibs`

### DIFF
--- a/.github/workflows/build-n-release.yml
+++ b/.github/workflows/build-n-release.yml
@@ -68,7 +68,7 @@ jobs:
           py -0p
           pip list
 
-      - name: Upgrade msys2 (windows, gcc)
+      - name: Install msys2 dependencies (windows, gcc)
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc'
         uses: msys2/setup-msys2@v2
         with:
@@ -79,35 +79,40 @@ jobs:
             libtool
             autoconf-wrapper
             automake-wrapper
-  
-      - name: Upgrade msys2/mingw32 (windows, gcc)
-        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc' && matrix.arch == 'x86'
-        uses: msys2/setup-msys2@v2
-        with:
-          msystem: msys
-          release: false
-          update: true
-          install: mingw-w64-i686-toolchain
-          
-      - name: Upgrade msys2/mingw64 (windows, gcc)
-        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc' && matrix.arch == 'amd64'
-        uses: msys2/setup-msys2@v2
-        with:
-            msystem: msys
-            release: false
-            update: true
-            install: mingw-w64-x86_64-toolchain
 
-      - name: Disable standalone mingw (windows, gcc)
+      - name: Remove default mingw (windows, gcc)
         if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc'
         shell: python
         run: |
-          # the default msys2/mingw distribution installed on Windows runners is ucrt-based
-          # we need a msvcrt-based distro, so we pull the latest mingw-w64 msys2 package
+          # mingw distribution pre-installed on Windows runners is ucrt-based
+          # we'll deploy a different distro that is msvcrt-based
           import os
           os.rename('C:\\mingw32', 'C:\\mingw32.bak')
           os.rename('C:\\mingw64', 'C:\\mingw64.bak')
-            
+
+      # https://winlibs.com/
+      # https://github.com/brechtsanders/winlibs_mingw/tags
+      # https://github.com/marketplace/actions/setup-winlibs
+      - name: Install winlibs/mingw32 (windows, gcc)
+        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc' && matrix.arch == 'x86'
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          tag: 16.2.0posix-14.0.0-msvcrt-r1
+          with_clang: false
+          destination: C:/
+          add_to_path: false
+          architecture: i686
+
+      - name: Install winlibs/mingw32 (windows, gcc)
+        if: startsWith(matrix.os, 'windows') && matrix.compiler == 'gcc' && matrix.arch == 'amd64'
+        uses: bwoodsend/setup-winlibs-action@v1
+        with:
+          tag: 16.2.0posix-14.0.0-msvcrt-r1
+          with_clang: false
+          destination: C:/
+          add_to_path: false
+          architecture: x86_64
+
       - name: Print debug info (macos)
         if: startsWith(matrix.os, 'macos')
         run: |

--- a/.github/workflows/build-n-release.yml
+++ b/.github/workflows/build-n-release.yml
@@ -227,7 +227,7 @@ jobs:
   package:
     name: Package
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: windows-latest   # must match the platform that built `makensis`
     steps:
 
     # `fetch-depth: 0` pulls full branch history. Needed to extract the SVN revision number from git comments
@@ -252,6 +252,8 @@ jobs:
           'artifacts',
           distro_x86_dir='.instdist-x86',
           distro_amd64_dir='.instdist-amd64',
+          distro_x86_re=r'^.+-windows-[\w\.]+-x86-gcc$',
+          distro_amd64_re=r'^.+-windows-[\w\.]+-amd64-gcc$'
           )
 
     - name: Build NSIS setup (x86)

--- a/.github/workflows/build-n-release.yml
+++ b/.github/workflows/build-n-release.yml
@@ -47,11 +47,11 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         run: sudo DEBIAN_FRONTEND=noninteractive apt-get install -y scons mingw-w64
 
-      - name: Upgrade python (windows)
-        if: startsWith(matrix.os, 'windows')
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
+      # - name: Upgrade python (windows)
+      #   if: startsWith(matrix.os, 'windows')
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: '3.x'
 
       - name: Install dependencies (windows)
         if: startsWith(matrix.os, 'windows')

--- a/nsis_build.py
+++ b/nsis_build.py
@@ -10,10 +10,10 @@ from nsis_version import *
 
 scriptdir = path.dirname(path.abspath(__file__))
 
-def run(args):
+def run(args, cwd=None):
     """ Execute subprocess and raise exit code exceptions. """
     print(f">> {args}")
-    exitcode = Popen(args).wait()
+    exitcode = Popen(args, cwd=cwd).wait()
     if exitcode != 0:
         raise OSError(exitcode, f"subprocess exit code {exitcode}")
 

--- a/nsis_build.py
+++ b/nsis_build.py
@@ -145,10 +145,10 @@ def build_zlib(compiler, arch, zlibdir):
     curdir = path.curdir
     os.chdir(zlibdir)
     if compiler == 'gcc' and os.name == 'nt':
-        args = [f'mingw32-make.exe', '-fwin32/Makefile.gcc', f'LOC=-D_WIN32_WINNT=0x0400 -static', 'zlib1.dll']
+        args = [f'mingw32-make.exe', '-fwin32/Makefile.gcc', f'LOC=-D_WIN32_WINNT=0x0400 -static', 'zlib1.dll', 'libz.a']
     elif compiler == 'gcc' and os.name != 'nt':
         prefixes = {'x86': 'i686-w64-mingw32-', 'amd64': 'x86_64-w64-mingw32-'}
-        args = ['make', '-fwin32/Makefile.gcc', f'PREFIX={prefixes[arch]}', 'LOC=-D_WIN32_WINNT=0x0400 -static', 'zlib1.dll']
+        args = ['make', '-fwin32/Makefile.gcc', f'PREFIX={prefixes[arch]}', 'LOC=-D_WIN32_WINNT=0x0400 -static', 'zlib1.dll', 'libz.a']
     elif compiler == 'msvc':
         args = [f'cmd.exe', '/c', 'call', "vcvarsall.bat", arch, '&&', 'nmake.exe', '-f', 'win32/Makefile.msc', f'LOC=/MT', 'zlib1.dll', 'zdll.lib']
     run(args)

--- a/nsis_build.py
+++ b/nsis_build.py
@@ -170,12 +170,14 @@ def build_cppunit(compiler, arch, cppunitdir):
             rf"--bindir={win_to_posix(path.join(cppunitdir, 'bin'))}"
             ]
         for args in [
-            ['sh', './autogen.sh'],
-            ['sh', './configure', f'MAKE={prefix}make'] + outargs + ['LDFLAGS=-static', '--disable-silent-rules', '--disable-dependency-tracking', '--disable-doxygen', '--disable-html-docs', '--disable-latex-docs'],
-            [f'{prefix}make'],
-            [f'{prefix}make', 'install']
+            {'args':['sh', './autogen.sh'], 'cwd':None},
+            {'args':['sh', './configure', f'MAKE={prefix}make'] + outargs + ['LDFLAGS=-static', '--disable-silent-rules', '--disable-dependency-tracking', '--disable-doxygen', '--disable-html-docs', '--disable-latex-docs'], 'cwd':None},
+            {'args':[f'{prefix}make'],            'cwd':path.join(cppunitdir, 'include')},
+            {'args':[f'{prefix}make'],            'cwd':path.join(cppunitdir, 'src')},
+            {'args':[f'{prefix}make', 'install'], 'cwd':path.join(cppunitdir, 'include')},
+            {'args':[f'{prefix}make', 'install'], 'cwd':path.join(cppunitdir, 'src')},
             ]:
-            run(args)
+            run(args['args'], args['cwd'])
     elif compiler == 'msvc':
         args = ['cmd.exe', '/c', 'call', 'vcvarsall.bat', arch, '&&', 'msbuild', '/m', '/t:build', path.join(cppunitdir, 'src', 'cppunit', 'cppunit.vcxproj'), '/p:Configuration=Release', f'/p:Platform={vars["archName"]}', f'/p:PlatformToolset={vars["platformToolset" ]}']
         run(args)


### PR DESCRIPTION
Our NSIS distro targets all Windows platforms starting from Windows NT 4.0 and later.
Building compatible binaries requires special compiler settings (e.g. `-march=pentium2`).
Older mingw versions used to support these options, but more recent versions (2025+) do not adhere to them strictly, generating machine code that may not run on older Windows platforms.
Fortunately, there's an alternative mingw distro available at https://winlibs.com
We'll remove the preinstalled mingw from the Windows GitHub runners, and replace it with `winlibs`.
This ensures that we have full control over the compiler and the output binaries.